### PR TITLE
fix: warp_raster_hb dst_ndv default uses GDAL type enum instead of nodata

### DIFF
--- a/hazelbean/geoprocessing_extension.py
+++ b/hazelbean/geoprocessing_extension.py
@@ -513,7 +513,7 @@ def warp_raster_hb(
         src_ndv = base_raster_info['nodata']
 
     if dst_ndv is None:
-        dst_ndv = base_raster_info['datatype']
+        dst_ndv = base_raster_info['ndv']
         if dst_ndv is None:
             if output_data_type < 5:
                 dst_ndv = 255


### PR DESCRIPTION
## Bug

In `warp_raster_hb`, when `dst_ndv=None` is passed (the default), the fallback at line 516 reads the wrong key:

```python
if dst_ndv is None:
    dst_ndv = base_raster_info['datatype']   # <-- bug: 'datatype' returns the GDT type enum int
    if dst_ndv is None:                      # <-- never True after the line above
        if output_data_type < 5:
            dst_ndv = 255
        else:
            dst_ndv = -9999.0
```

`base_raster_info['datatype']` is the GDAL `GDT_*` type enum (`1`=Byte, `6`=Float32, `7`=Float64, …) — not a nodata value. This means:

1. `dst_ndv` silently takes the value `6` (or whatever the source's GDT enum is) and is passed to `gdal.Warp(dstNodata=6)`. The output raster's nodata tag is then `6.0`, so any pixel whose value happens to equal `6` is silently masked downstream.
2. The intended `255` / `-9999.0` fallback below is dead code, because the inner `if dst_ndv is None:` is always False after the assignment above.

## Reproducer (against `origin/main`, unpatched)

```python
import os, tempfile
import numpy as np
import rasterio
from rasterio.transform import from_origin
import hazelbean as hb

with tempfile.TemporaryDirectory() as td:
    src = os.path.join(td, 'src.tif')
    dst = os.path.join(td, 'dst.tif')

    data = np.array([[10, 20, 30, 9999],
                     [40, 50, 60, 9999],
                     [70, 80, 90, 9999],
                     [9999, 9999, 9999, 9999]], dtype=np.float32)
    with rasterio.open(
        src, 'w', driver='GTiff',
        height=4, width=4, count=1, dtype=data.dtype,
        crs='EPSG:4326',
        transform=from_origin(-50.0, -10.0, 0.001, 0.001),
        nodata=9999,
    ) as ds:
        ds.write(data, 1)

    hb.warp_raster_hb(
        base_raster_path=src,
        target_pixel_size=(0.001, -0.001),
        target_raster_path=dst,
        resample_method='near',
        src_ndv=None, dst_ndv=None,
    )

    with rasterio.open(dst) as ds:
        print('output ndv tag:', ds.nodata)   # before fix: 6.0    after fix: 9999.0
```

- **Before this fix**: `output ndv tag: 6.0` (the Float32 GDT enum)
- **After this fix**: `output ndv tag: 9999.0` (correctly inherited from the source)

## Fix

Read the scalar nodata key (`'ndv'`, defined at line 1614 as `raster.GetRasterBand(1).GetNoDataValue()`) instead of `'datatype'`. When the source has a declared nodata, that's now propagated to the destination; when it doesn't, `'ndv'` returns `None` and the existing `255` / `-9999.0` fallback finally becomes reachable.

## Scope

Surgical: one logical line change inside `warp_raster_hb`, plus a comment explaining the fix. No public API change.

## Not in this PR (worth a separate look)

The `src_ndv=None` branch at line 512 also reads `base_raster_info['nodata']`, which returns a per-band list rather than a scalar. Passing a Python list to `gdal.Warp(srcNodata=...)` is a code smell, but I could not produce a single-band reproducer where it caused incorrect output on current GDAL. The snap_statics workaround at `NZ_brazil_dev/scripts/snap_statics.py` was written against an empirically-observed all-zero failure that I now can't pin to this specific code path, so I'd rather not include a speculative fix here. If the actual trigger surfaces, a separate PR with a real reproducer is the right move.