### PR TITLE
Add per-machine env loader (~/.config/hazelbean/machine.env)

### DIFF
--- a/hazelbean/__init__.py
+++ b/hazelbean/__init__.py
@@ -10,6 +10,12 @@ gdal_bin = os.path.join(conda_prefix, "Library", "bin")
 if os.path.exists(gdal_bin) and gdal_bin not in os.environ["PATH"]:
     os.environ["PATH"] = gdal_bin + os.pathsep + os.environ["PATH"]
 
+# Per-machine, never-committed settings (e.g. gtappy's solve-backend connection vars)
+# live in ~/.config/hazelbean/machine.env and are loaded here into any env-var gaps.
+# Real environment variables always win. See hazelbean/machine_env.py.
+from hazelbean.machine_env import load_user_machine_env
+load_user_machine_env()
+
 import hazelbean.config # Needs to be imported before core so that hb.config.LAST_TIME_CHECK is set for hb.timer()
 from hazelbean.config import *
 

--- a/hazelbean/machine_env.py
+++ b/hazelbean/machine_env.py
@@ -1,0 +1,56 @@
+"""Per-machine environment config.
+
+Loads KEY=value pairs from a per-user file (default ~/.config/hazelbean/machine.env)
+into os.environ when hazelbean is imported, filling gaps only — a variable already
+set in the real environment always wins. This is the devstack-wide home for
+per-machine, never-committed settings (e.g. gtappy's solve-backend connection vars
+GTAP_VM_SSH_HOST / GTAP_GEMPACK_DIR), so they work identically on any OS and inside
+IDE debug runs without shell rc files.
+
+The format tolerates a leading 'export ' and trailing '# comment' on each line, so
+the same file can also be sourced from a POSIX shell.
+"""
+import os
+
+USER_MACHINE_ENV_PATH = os.path.join(os.path.expanduser('~'), '.config', 'hazelbean', 'machine.env')
+
+
+def _parse_value(raw):
+    """Strip surrounding quotes (and anything after the closing quote) or, for
+    unquoted values, a trailing inline comment."""
+    raw = raw.strip()
+    if raw[:1] in ('"', "'"):
+        quote = raw[0]
+        end = raw.find(quote, 1)
+        if end != -1:
+            return raw[1:end]
+    return raw.split('#', 1)[0].strip()
+
+
+def load_user_machine_env(path=None):
+    """Load KEY=value lines from path into os.environ with setdefault semantics.
+
+    Returns a dict of the variables the file supplied (regardless of whether each
+    one won over a pre-existing environment variable). Missing file -> empty dict,
+    so machines without a config file are unaffected.
+    """
+    if path is None:
+        path = USER_MACHINE_ENV_PATH
+    if not os.path.isfile(path):
+        return {}
+    supplied = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, raw_value = line.split('=', 1)
+            key = key.strip()
+            if key.startswith('export '):
+                key = key[len('export '):].strip()
+            if not key or ' ' in key:
+                continue
+            value = _parse_value(raw_value)
+            supplied[key] = value
+            os.environ.setdefault(key, value)
+    return supplied

--- a/hazelbean_tests/unit/test_machine_env.py
+++ b/hazelbean_tests/unit/test_machine_env.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+import pytest
+
+from hazelbean.machine_env import load_user_machine_env
+
+
+def write_env_file(tmp_path, text):
+    p = tmp_path / "machine.env"
+    p.write_text(text)
+    return str(p)
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert load_user_machine_env(str(tmp_path / "nope.env")) == {}
+
+
+def test_plain_key_value(tmp_path, monkeypatch):
+    monkeypatch.delenv("HB_TEST_PLAIN", raising=False)
+    path = write_env_file(tmp_path, "HB_TEST_PLAIN=hello\n")
+    supplied = load_user_machine_env(path)
+    assert supplied == {"HB_TEST_PLAIN": "hello"}
+    assert os.environ["HB_TEST_PLAIN"] == "hello"
+
+
+def test_real_environment_wins(tmp_path, monkeypatch):
+    monkeypatch.setenv("HB_TEST_WINS", "from_real_env")
+    path = write_env_file(tmp_path, "HB_TEST_WINS=from_file\n")
+    supplied = load_user_machine_env(path)
+    assert supplied == {"HB_TEST_WINS": "from_file"}
+    assert os.environ["HB_TEST_WINS"] == "from_real_env"
+
+
+def test_shell_template_format(tmp_path, monkeypatch):
+    # The gtappy modality_env template verbatim: export prefix, quotes,
+    # inline comments, blank lines, comment-only lines, backslash paths.
+    for k in ("GTAP_VM_SSH_HOST", "GTAP_VM_DISK_PREFIX", "GTAP_GEMPACK_DIR"):
+        monkeypatch.delenv(k, raising=False)
+    text = (
+        "# GTAP modality dispatch -- per-machine connection config\n"
+        "\n"
+        "export GTAP_VM_SSH_HOST='me@192.168.64.2'         # e.g. Chiara@192.168.64.4\n"
+        'export GTAP_VM_DISK_PREFIX="C:/Users/me/Files"  # the VM Files dir\n'
+        "export GTAP_GEMPACK_DIR='C:\\GP'\n"
+        "# export GTAP_SC_SSH_HOST='<user>@<cluster>'\n"
+    )
+    path = write_env_file(tmp_path, text)
+    supplied = load_user_machine_env(path)
+    assert supplied == {
+        "GTAP_VM_SSH_HOST": "me@192.168.64.2",
+        "GTAP_VM_DISK_PREFIX": "C:/Users/me/Files",
+        "GTAP_GEMPACK_DIR": "C:\\GP",
+    }
+    assert os.environ["GTAP_VM_SSH_HOST"] == "me@192.168.64.2"
+    assert os.environ["GTAP_GEMPACK_DIR"] == "C:\\GP"
+
+
+def test_unquoted_inline_comment_stripped(tmp_path, monkeypatch):
+    monkeypatch.delenv("HB_TEST_COMMENT", raising=False)
+    path = write_env_file(tmp_path, "HB_TEST_COMMENT=bare_value # trailing note\n")
+    supplied = load_user_machine_env(path)
+    assert supplied == {"HB_TEST_COMMENT": "bare_value"}
+
+
+def test_malformed_lines_skipped(tmp_path, monkeypatch):
+    monkeypatch.delenv("HB_TEST_OK", raising=False)
+    text = (
+        "no_equals_sign_here\n"
+        "two words=bad_key_skipped\n"
+        "HB_TEST_OK=fine\n"
+    )
+    path = write_env_file(tmp_path, text)
+    supplied = load_user_machine_env(path)
+    assert supplied == {"HB_TEST_OK": "fine"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- New `hazelbean/machine_env.py`: loads KEY=value lines from `~/.config/hazelbean/machine.env` into `os.environ` at import, setdefault semantics (real env vars always win; missing file is a no-op).
- Called from `hazelbean/__init__.py` next to the existing PATH/GDAL env setup, so any repo that imports hazelbean gets it for free.
- Parser tolerates `export ` prefixes, quotes, and trailing inline comments, so gtappy's `modality_env.example.sh` works verbatim as the file format (and the same file can still be sourced from a shell).

This gives per-machine, never-committed settings (e.g. gtappy's GTAP_VM_SSH_HOST / GTAP_GEMPACK_DIR solve-backend connection) a cross-platform home that also works inside IDE debug runs — no shell rc files needed. Companion PR in gtappy_dev updates the template's setup instructions.

## Test plan
- 6 new unit tests in `hazelbean_tests/unit/test_machine_env.py` (template format verbatim, env-wins precedence, quoting/comments, malformed lines) — all pass.
- End-to-end verified with a scratch HOME: `import hazelbean` → file loaded → `gtappy_utils._modality_conn('vm_windows')` returns the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)