### PR TITLE
Name-driven *_path hydration; git-aware project dir; skip-aware get_path

### DIFF
--- a/hazelbean/assign_to_object.py
+++ b/hazelbean/assign_to_object.py
@@ -35,9 +35,13 @@ shim, exactly as initialize_definitions.py argues for post_process hooks.
 Reconciliation decisions (where the four originals disagreed):
   * Path detection: the originals used three rules -- gtappy's `'.' in value[-5:-1]`
     (an extension test that silently FAILS for >4-char extensions like .geojson),
-    and seals' `'.' in value` (treats any dotted string as a path). Unified here to
-    an anchored extension regex OR a path separator -- a strict superset of the
-    useful cases and a fix for both originals' bugs.
+    and seals' `'.' in value` (treats any dotted string as a path). First unified to
+    an anchored extension regex OR a path separator; since 2026-07-24 hydration is
+    NAME-driven instead (`*_path` columns resolve, everything else stays literal),
+    because no value heuristic can separate ssh targets (user@192.168.64.2),
+    backend-machine paths (C:\\GP) or free text (Expansion/Loss) from local ref
+    paths. The value heuristic survives as the public `looks_like_path` for
+    consumers of value-conditional columns (aoi, calibration_parameters_source).
   * gtappy's row parser ran `hb.parse_flex_to_python_object` as a pre-pass; the
     seals parsers did not. Dropped in favor of explicit [list]/{dict} literal
     parsing, which is the part that actually mattered and now applies to both
@@ -58,14 +62,6 @@ import hazelbean as hb
 _PATH_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
 
 
-def _is_floatable(value):
-    try:
-        float(value)
-        return True
-    except (ValueError, TypeError):
-        return False
-
-
 def _is_intable(value):
     try:
         int(value)
@@ -74,8 +70,17 @@ def _is_intable(value):
         return False
 
 
-def _looks_like_path(value):
-    """Unified replacement for the three divergent path heuristics."""
+def looks_like_path(value):
+    """Value-based path heuristic: a path separator or a trailing .ext.
+
+    Since 2026-07-24 this no longer drives hydration -- `parse_attribute_value`
+    resolves paths by NAME (`*_path` columns), because no value heuristic can
+    separate an ssh target (user@192.168.64.2), a backend-machine path (C:\\GP)
+    or free text ('Expansion/Loss') from a local ref path. It stays public for
+    consumers of value-conditional columns whose values are only SOMETIMES paths
+    (e.g. aoi, calibration_parameters_source): gate on looks_like_path(value),
+    then resolve with get_path(..., leave_ref_path_if_fail=True).
+    """
     s = str(value).strip()
     if s == "" or s.lower() == "nan" or s == "skip":
         return False
@@ -152,13 +157,14 @@ def parse_attribute_value(input_object, attribute_name, attribute_value):
         1. cat-ears (`<^attr^>`) resolved against `input_object`'s attributes
         2. explicit `[list]` literal (with `int(...)`/`float(...)` token casts)
         3. explicit `{dict}` literal
-        4. path-like string -> `input_object.get_path(...)`
+        4. `*_path`-named column -> `input_object.get_path(...)` (name-driven,
+           per the EE Spec convention that path-bearing columns are named *_path;
+           blank/'skip' pass through, 'nan' -> None)
         5. `*year*`-named column -> int / space-delimited list-of-int parsing
         6. `*dimensions*`-named column -> space-delimited list-of-str parsing
         7. literal 'nan' -> None; otherwise the value unchanged
     """
     value = attribute_value
-    is_floatable = _is_floatable(value)
     is_intable = _is_intable(value)
 
     # 1. cat-ears: resolve placeholders against already-set attributes (seals_utils
@@ -175,12 +181,23 @@ def parse_attribute_value(input_object, attribute_name, attribute_value):
         if stripped.startswith("{") and stripped.endswith("}"):
             return _parse_dict_literal(value)
 
-    # 4. paths -- checked before year/dimensions so e.g. base_year_lulc_path
-    # (name contains 'year') still resolves as a path.
-    if _looks_like_path(value) and not is_floatable:
+    # 4. paths -- name-driven since 2026-07-24 (was value-driven, which get_path'd
+    # anything dotted or slashed: ssh targets, backend-machine paths, free text).
+    # Checked before year/dimensions so e.g. base_year_lulc_path (name contains
+    # 'year') still resolves as a path. Columns whose values are only sometimes
+    # paths (aoi, calibration_parameters_source) resolve at their consumers via
+    # the public looks_like_path + get_path(leave_ref_path_if_fail=True).
+    if str(attribute_name).endswith("_path"):
+        if not isinstance(value, str):
+            return None if str(value).lower() == "nan" else value
+        stripped = value.strip()
+        if stripped == "" or stripped == "skip":
+            return value
+        if stripped.lower() == "nan":
+            return None
         if has_cat_ears:
-            return input_object.get_path(value, leave_ref_path_if_fail=True)
-        return input_object.get_path(value)
+            return input_object.get_path(stripped, leave_ref_path_if_fail=True)
+        return input_object.get_path(stripped)
 
     if "year" in attribute_name:
         return _parse_year(value, attribute_name, is_intable)

--- a/hazelbean/project_flow.py
+++ b/hazelbean/project_flow.py
@@ -361,11 +361,47 @@ class ProjectFlow(object):
     def __repr__(self):
         return 'Hazelbean ProjectFlow object. ' # +  hb.pp(self.__dict__, return_as_string=True)
 
+    def _derive_default_project_dir(self):
+        """Resolve the bare-constructor default ('script_parent') git-aware.
+
+        Plain folder: the script's parent dir, as always. But if the calling script
+        lives inside a git repo, never put project outputs in the repo: walk up to the
+        repo root, step one level above it, and land at <that dir>/projects/<name>,
+        where <name> is the run file's stem minus any 'run_' prefix. For a repo in the
+        standard devstack layout (~/Files/<stack>/<repo>) this reproduces the house
+        convention (~/Files/<stack>/projects/<name>) without the run file spelling it
+        out. An explicit project_dir argument bypasses all of this.
+        """
+        script_parent = str(Path(self.script_dir).parent)
+        if not getattr(self, 'calling_script', None):
+            return script_parent
+
+        repo_root = None
+        d = Path(self.script_dir)
+        while True:
+            if (d / '.git').exists():  # dir in a normal clone, file in a worktree
+                repo_root = d
+                break
+            if d.parent == d:
+                break
+            d = d.parent
+        if repo_root is None:
+            return script_parent
+
+        name = Path(self.calling_script).stem
+        if name.startswith('run_'):
+            name = name[len('run_'):]
+        derived = str(repo_root.parent / 'projects' / name)
+        hb.log('Bare ProjectFlow(): calling script is inside the git repo at ' + str(repo_root)
+               + ', so the project dir is placed outside the repo at ' + derived
+               + '. Pass project_dir explicitly to override.')
+        return derived
+
     def set_project_dir(self, project_dir=None):
         # Resolve the project_dir: an explicit arg wins; otherwise keep an already-set
         # project_dir (e.g. from a prior call); otherwise fall back to the CWD.
         if project_dir == 'script_parent':
-            self.project_dir = str(Path(self.script_dir).parent)
+            self.project_dir = self._derive_default_project_dir()
         elif project_dir:
             self.project_dir = project_dir
         elif not getattr(self, 'project_dir', None):
@@ -659,6 +695,15 @@ class ProjectFlow(object):
                          '(returns the would-be path under the first searched root).')
             return '\n'.join(lines)
 
+        # Skip-aware failure: when the current task is skipped (p.run_this == 0), its
+        # pre-gate code runs purely to PUBLISH paths for later tasks — nothing is about
+        # to consume the file, so not-found must not be fatal. Form the would-be path
+        # and defer any failure to the next task that actually runs and consumes it.
+        # run_this is None outside the task loop (e.g. in the run file), where
+        # fail-fast on a typo'd ref_path is still correct.
+        _run_this = getattr(self, 'run_this', None)
+        in_skipped_task = _run_this is not None and not _run_this
+
         if os.path.isabs(relative_path):
             # Check that it has one of the possible_dirs already embedded in it
             found_possible_dir_in_input = False
@@ -686,6 +731,10 @@ class ProjectFlow(object):
                 elif hb.path_exists(relative_path):
                     hb.log('WARNING: You gave an absolute path to hb.get_path. It still might work if it found the possible_dirs in the path and removed them, but this is not good practice. Inputted path: ', relative_path, 'Possible dirs: ', possible_dirs, include_script_location=True)
                     return relative_path
+                elif in_skipped_task:
+                    hb.log('get_path (skipped task): absolute path ' + str(path_as_inputted)
+                           + ' was not found; publishing it as-is for later tasks.')
+                    return path_as_inputted
                 else:
                     raise NameError('get_path was given an absolute path it could not resolve (absolute paths are '
                                     'not good practice here — prefer a ref_path relative to the searched roots).\n'
@@ -694,18 +743,24 @@ class ProjectFlow(object):
         if leave_ref_path_if_fail:
             return path_as_inputted
 
-        if raise_error_if_fail:
+        if raise_error_if_fail and not in_skipped_task:
             raise NameError(_not_found_message())
 
-        # Caller opted out of raising (raise_error_if_fail=False): assume the file is
-        # about to be generated and return the would-be path under the first root.
-        # Log the assumption so a typo'd ref_path leaves a diagnostic trail instead
-        # of silently producing a phantom path.
+        # Deferred failure: either the caller opted out of raising
+        # (raise_error_if_fail=False, e.g. a task about to generate the file) or the
+        # current task is skipped and this call is only publishing a path. Return the
+        # would-be path under the first root and log the assumption so a typo'd
+        # ref_path leaves a diagnostic trail instead of silently producing a phantom path.
         possible_dirs = [i for i in possible_dirs if i is not None and i != 'input_bucket_name']
         path = os.path.join(possible_dirs[0], relative_path)
-        hb.log('get_path: ' + str(path_as_inputted) + ' was not found in any searched root; '
-               'assuming it will be generated at ' + str(path)
-               + '. If you expected it to exist, check the ref_path spelling.')
+        if in_skipped_task:
+            hb.log('get_path (skipped task): ' + str(path_as_inputted) + ' was not found in any searched root; '
+                   'publishing would-be path ' + str(path) + ' for later tasks. Any real failure will surface '
+                   'in the next task that consumes it.')
+        else:
+            hb.log('get_path: ' + str(path_as_inputted) + ' was not found in any searched root; '
+                   'assuming it will be generated at ' + str(path)
+                   + '. If you expected it to exist, check the ref_path spelling.')
         return path
 
     def write_args_to_project(self, args):


### PR DESCRIPTION
Part of the run_mode + name-driven-hydration line (2026-07-24/26). Same-named branches in seals, gtappy, gtap_invest, seals_cgebox_dev, earth_economy_devstack, and ngfs_pnas — merge together.

## Changes
- **assign_to_object.py**: grammar rule 4 resolves paths by NAME (`*_path` columns) instead of value heuristic. Fixes hydration crash on filled `vm_ssh_host` (`jajohns@192.168.64.2` — the `.2` matched the extension regex) and latent false positives on backend-machine paths (`C:\GP`) and free text (`Expansion/Loss`). `looks_like_path` is now public for value-conditional consumers.
- **project_flow.py**: git-aware bare-constructor default project dir (`_derive_default_project_dir`); skip-aware `get_path` (skipped tasks publish would-be paths instead of raising).

## Verification
- 12 grammar unit cases (ssh target, Windows paths, free text stay literal; ref paths, blank/skip/nan, year parsing intact)
- ngfs_pnas test dry-run: all `_path` columns resolve, connection values literal, `vm_windows` modality detected
- `run_minimal_example.py` end-to-end in env1

🤖 Generated with [Claude Code](https://claude.com/claude-code)