### PR TITLE
Add support for shared data roots in get_path

### DIFF
--- a/hazelbean/cloud_utils.py
+++ b/hazelbean/cloud_utils.py
@@ -1,7 +1,4 @@
 from google.cloud import storage
-from googleapiclient.discovery import build
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 import pickle
 import os
 import os
@@ -231,6 +228,15 @@ def download_google_cloud_blob(bucket_name, source_blob_name, credentials_path, 
 
 def list_files_in_google_drive_folder(input_folder_id, credentials_path):
     # NYI! This approach uses google drive, but htat means I need to verify gtapinvest as an app with google. not worth it. switching back to gsutil for now.
+    # Nothing in the devstack calls this. To read data off a Drive shared drive, mount it
+    # with Drive for Desktop and point HB_SHARED_DATA_DIRS at its base_data mirror --
+    # get_path then treats it as a shared root (see ProjectFlow.shared_root_is_available).
+    # The Drive-API imports are function-local so this dead path does not make
+    # googleapiclient / google_auth_oauthlib hard import requirements of the whole module.
+    from googleapiclient.discovery import build
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from google.auth.transport.requests import Request
+
     # If modifying these SCOPES, delete the file token.pickle.
     SCOPES = ['https://www.googleapis.com/auth/drive']
 
@@ -289,8 +295,14 @@ def promote_ref_path_to_base_data(input_path, pivot_path, base_data_dir):
 
     # Move the file to the base_data_dir
     os.rename(input_path, joined_path)
-def download_gdrive_refpath(ref_path, base_data_dir=None, data_credentials_path=None, input_bucket_name=None, create_shortcut=False, intermediate_path_override=None, verbose=False):
+def download_bucket_refpath(ref_path, base_data_dir=None, data_credentials_path=None, input_bucket_name=None, create_shortcut=False, intermediate_path_override=None, verbose=False):
+    """Download a ref_path from the cloud STORAGE BUCKET into base_data_dir, if missing.
 
+    Named for the bucket because that is what it talks to. It has nothing to do with
+    Google Drive despite the old download_gdrive_refpath spelling (kept below as an
+    alias for existing callers) -- for Drive, mount the shared drive and configure
+    HB_SHARED_DATA_DIRS so ProjectFlow.get_path picks it up as a shared root.
+    """
     source_blob_name =  ref_path.replace('\\', '/')
     default_bucket = 'gtap_invest_seals_2023_04_21'
     if input_bucket_name is None:
@@ -301,7 +313,10 @@ def download_gdrive_refpath(ref_path, base_data_dir=None, data_credentials_path=
 
     destination_file_path = os.path.join(base_data_dir, ref_path)
 
-    if hb.path_exists(destination_file_path):
+    # Download only when the file is MISSING. This test used to be inverted: it
+    # downloaded when the file already existed, and logged 'already exists. Skipping
+    # download.' when it did not.
+    if not hb.path_exists(destination_file_path):
 
         if is_internet_available(1):
             if data_credentials_path is not None:
@@ -325,6 +340,11 @@ def download_gdrive_refpath(ref_path, base_data_dir=None, data_credentials_path=
     else:
         hb.log('The file ' + str(destination_file_path) + ' already exists. Skipping download.')
         return destination_file_path
+
+
+# Deprecated spelling. The function has always downloaded from the storage bucket, never
+# from Google Drive; kept so existing callers keep working.
+download_gdrive_refpath = download_bucket_refpath
 
 
 def download_file(url, target_path, chunk_size=1024 * 1024, retries=3):

--- a/hazelbean/os_utils.py
+++ b/hazelbean/os_utils.py
@@ -1481,6 +1481,82 @@ def path_abs(input_relative_path):
         return "Failed path_abs on " + str(input_relative_path)
 
 
+# Files GDAL and OGR write beside a dataset. Copying a raster without these silently
+# drops statistics, overviews and georeferencing -- a performance and rendering
+# regression rather than an error, so it is easy to miss.
+GDAL_SIDECAR_SUFFIXES = ('.aux.xml', '.ovr', '.tfw', '.wld', '.prj', '.msk', '.vat.dbf', '.xml')
+
+# Google Drive stores its native documents as ~100-byte JSON pointers with these
+# extensions. They look like files on a mounted drive but contain no data.
+GOOGLE_NATIVE_EXTENSIONS = ('.gdoc', '.gsheet', '.gslides', '.gform', '.gdraw', '.gmap', '.gsite')
+
+
+def is_google_native_file(path):
+    """True for Drive's placeholder documents (.gsheet, .gdoc, ...), which hold no data."""
+    return os.path.splitext(str(path))[1].lower() in GOOGLE_NATIVE_EXTENSIONS
+
+
+def cache_file_from_shared_root(src, dst, verbose=False):
+    """Copy src to dst atomically, bringing any sidecars, and return dst.
+
+    Used by ProjectFlow.get_path to pull a ref_path off a read-only shared root (a
+    mounted lab drive, a group scratch dir) into the local base_data dir, so that
+    every later run resolves it locally and never touches the shared root again.
+
+    Atomic on purpose: the copy lands on '<dst>.partial.<pid>', is size-verified, and
+    is then os.replace()d onto the final name. A run killed mid-copy must never leave
+    a truncated file behind, because a truncated file passes hb.path_exists() forever
+    afterwards and silently poisons every subsequent run. The pid in the temp name
+    keeps two parallel workers requesting the same file from colliding; os.replace is
+    atomic, so last-writer-wins is harmless.
+
+    Never writes to the source. Shared roots are read-only by contract.
+    """
+    if not os.path.isfile(src):
+        raise NameError('cache_file_from_shared_root needs an existing source file, got: ' + str(src))
+
+    dst_dir = os.path.dirname(dst)
+    if dst_dir and not os.path.exists(dst_dir):
+        hb.create_directories(dst_dir)
+
+    def _atomic_copy(one_src, one_dst):
+        tmp = one_dst + '.partial.' + str(os.getpid())
+        try:
+            shutil.copyfile(one_src, tmp)
+            src_size = os.path.getsize(one_src)
+            tmp_size = os.path.getsize(tmp)
+            if src_size != tmp_size:
+                raise IOError('Short read copying ' + str(one_src) + ': expected ' + str(src_size)
+                              + ' bytes, got ' + str(tmp_size)
+                              + '. The shared root may have stalled mid-stream.')
+            os.replace(tmp, one_dst)
+        except BaseException:
+            # Leave nothing half-written for a later run to mistake for a good file.
+            if os.path.exists(tmp):
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+            raise
+
+    _atomic_copy(src, dst)
+    if verbose:
+        hb.log('Cached ' + str(src) + ' to ' + str(dst))
+
+    # Sidecars. A shapefile's siblings share the file root rather than extending the
+    # full filename, so they are handled separately from the GDAL suffix set.
+    if os.path.splitext(src)[1].lower() == '.shp':
+        for extension in ('.dbf', '.shx', '.prj', '.cpg', '.sbn', '.sbx', '.qix', '.shp.xml'):
+            sidecar_src = path_replace_extension(src, extension)
+            if os.path.isfile(sidecar_src):
+                _atomic_copy(sidecar_src, path_replace_extension(dst, extension))
+    for suffix in GDAL_SIDECAR_SUFFIXES:
+        if os.path.isfile(src + suffix):
+            _atomic_copy(src + suffix, dst + suffix)
+
+    return dst
+
+
 def path_copy(src, dst, copy_tree=True, displace_overwrites=False, overwrite=True, verbose=False):
     copy_shutil_flex(src, dst, copy_tree=copy_tree, displace_overwrites=displace_overwrites, overwrite=overwrite, verbose=verbose)
 

--- a/hazelbean/project_flow.py
+++ b/hazelbean/project_flow.py
@@ -929,6 +929,12 @@ class ProjectFlow(object):
                     lines.append('    - shared data root (' + state + '): ' + str(shared_root))
             if 'input_bucket_name' in possible_dirs:
                 lines.append('    - cloud bucket: ' + str(self.input_bucket_name))
+            # Lands in front of someone at the moment they need it, rather than in a
+            # doc they would have to know to look for.
+            if not getattr(self, 'shared_data_dirs', None):
+                lines.append('  No shared data roots are configured. If this file lives on a lab drive or')
+                lines.append('  shared disk, run  hb-setup-machine-env  to detect and record one, or set')
+                lines.append('  HB_SHARED_DATA_DIRS by hand in ~/.config/hazelbean/machine.env.')
             lines.append('  If you expected this file to exist, check the ref_path spelling against base_data.')
             lines.append('  If a task generates this file, call get_path with raise_error_if_fail=False '
                          '(returns the would-be path under the first searched root).')

--- a/hazelbean/project_flow.py
+++ b/hazelbean/project_flow.py
@@ -25,6 +25,12 @@ L = hb.get_logger('project_flow')
 L.setLevel(logging.INFO)
 initial_logging_level = L.getEffectiveLevel()
 
+# get_path's possible_dirs list holds plain directory strings plus a few sentinels for
+# roots that need more than a path join. 'input_bucket_name' is the long-standing one
+# (the cloud bucket); this marks a read-only shared data root, whose path follows the
+# prefix. Not a valid path prefix on any platform, so it can never collide with a dir.
+SHARED_ROOT_SENTINEL_PREFIX = 'shared_data_root::'
+
 # module level get_path. Usually you want to use the project_level version
 def get_path(relative_path, *join_path_args, possible_dirs='default', prepend_possible_dirs=None, create_shortcut=False, download_destination_dir=None, strip_relative_paths_for_output=False, leave_ref_path_if_fail=False, verbose=False):
     # SUPER DANGEROUS TO USE IF YOU ACTUALLY WANT TO USE A PROJECT FLOW OBJECT.
@@ -341,6 +347,27 @@ class ProjectFlow(object):
         else:
             self.external_bulk_data_dir = None
 
+        # Read-only roots that mirror base_data's ref_path layout: a mounted lab drive
+        # (Google Drive for Desktop, Dropbox), a group scratch dir, an external disk.
+        # get_path searches them after base_data_dir and before the cloud bucket, and
+        # copies any hit into base_data_dir so later runs resolve locally.
+        #
+        # Configured per machine, because the mount path is a property of the machine
+        # (a Drive mount embeds the signed-in account) rather than of any project:
+        #   HB_SHARED_DATA_DIRS=/path/to/drive/base_data   in ~/.config/hazelbean/machine.env
+        # os.pathsep-separated for more than one. Unset (the default) means no shared
+        # roots and get_path behaves exactly as it did before this existed.
+        #
+        # A run file may also set p.shared_data_dirs = [...] directly.
+        self.shared_data_dirs = [i.strip() for i in
+                                 os.environ.get('HB_SHARED_DATA_DIRS', '').split(os.pathsep)
+                                 if i.strip()]
+
+        # Availability is cached per ProjectFlow: parallel iterators call get_path
+        # thousands of times per run, and stat-ing a network filesystem on each call is
+        # the performance trap that would make people turn this off.
+        self._shared_root_availability = {}
+
 
         # args is used by UI elements.
         self.args = {}
@@ -619,6 +646,29 @@ class ProjectFlow(object):
             else:
                 hb.log(f'skip_tasks: no task named {name!r} in this task tree — check spelling.')
 
+    def shared_root_is_available(self, shared_root):
+        """True if a configured shared root is present on this machine, cached per ProjectFlow.
+
+        A shared root is opportunistic by design: it is a mounted lab drive or group
+        scratch dir that some machines have and others cannot. Google Drive for Desktop
+        has no Linux client at all, so an absent root is the NORMAL state on the cluster,
+        not an error — get_path skips it and falls through to the cloud bucket.
+
+        Cached because get_path is called thousands of times per run inside parallel
+        iterators, and each check may hit a network filesystem.
+        """
+        if shared_root not in self._shared_root_availability:
+            try:
+                available = os.path.isdir(shared_root)
+            except OSError:
+                # A stale or unauthenticated mount can raise rather than return False.
+                available = False
+            self._shared_root_availability[shared_root] = available
+            if not available:
+                hb.log('Shared data root not available on this machine (skipping it in get_path): '
+                       + str(shared_root))
+        return self._shared_root_availability[shared_root]
+
     def set_base_data_dir(self, input_base_data_dir=None, match_string='seals/default_inputs'):
                 
         # Search over multiple possible places to find a base data dir that contains correct data then use it.
@@ -735,8 +785,16 @@ class ProjectFlow(object):
         # if len(join_path_args) > 1:
         #     to_insert = os.path.join(self.intermediate_dir, os.sep.join([path_as_inputted] + list(join_path_args)[:-1]))
         #     possible_dirs.insert(0, to_insert)
-        
-            # Check if self has google_drive_path attribute and if so, add it to the possible_dirs
+
+        # Shared data roots (a mounted lab drive, a group scratch dir) go after the local
+        # dirs and before the cloud bucket: local disk is fastest, a mount is free but
+        # slower, the bucket is slowest and costs egress. They are marked with a sentinel
+        # rather than added as plain dirs because a hit must be COPIED to base_data and the
+        # local path returned -- handing GDAL a path on a streaming filesystem is the thing
+        # this tier exists to avoid. No roots configured means nothing is appended and the
+        # ladder is exactly what it was.
+        for shared_root in getattr(self, 'shared_data_dirs', []):
+            possible_dirs.append(SHARED_ROOT_SENTINEL_PREFIX + shared_root)
 
         if not hasattr(self, 'input_bucket_name'):
             self.input_bucket_name = default_bucket
@@ -807,13 +865,33 @@ class ProjectFlow(object):
                         else:
                             pass
 
+                elif possible_dir.startswith(SHARED_ROOT_SENTINEL_PREFIX):
+                    # A read-only root mirroring base_data's ref_path layout. Copy any hit
+                    # into base_data and return the LOCAL path, which is what makes this a
+                    # cache rather than a symlink: the next run resolves at base_data and
+                    # never touches the shared root again.
+                    shared_root = possible_dir[len(SHARED_ROOT_SENTINEL_PREFIX):]
+                    if not self.shared_root_is_available(shared_root):
+                        continue
+
+                    shared_path = os.path.join(shared_root, relative_path)
+                    if os_utils.is_google_native_file(shared_path):
+                        # A Drive .gsheet/.gdoc is a ~100-byte JSON pointer, not data.
+                        continue
+
+                    if hb.path_exists(shared_path, verbose=verbose):
+                        local_path = os.path.join(self.base_data_dir, relative_path)
+                        os_utils.cache_file_from_shared_root(shared_path, local_path, verbose=verbose)
+                        hb.log('get_path: cached ' + str(relative_path) + ' from shared root '
+                               + str(shared_root) + ' to ' + str(local_path))
+                        if create_shortcut:
+                            os_utils.create_shortcut(destination_file_name, intermediate_path_override)
+                        return local_path
+
                 else:
 
                     path = os.path.join(possible_dir, relative_path)
 
-
-                    
-                    
 
                     if hb.path_exists(path, verbose=verbose):
                         if create_shortcut:
@@ -833,13 +911,22 @@ class ProjectFlow(object):
 
         # It wasnt found anywhere, so do some final checks and then use the default
         def _not_found_message():
-            searched = [i for i in possible_dirs if isinstance(i, str) and i != 'input_bucket_name']
+            searched = [i for i in possible_dirs if isinstance(i, str)
+                        and i != 'input_bucket_name'
+                        and not i.startswith(SHARED_ROOT_SENTINEL_PREFIX)]
             lines = ['get_path could not resolve a ref_path.',
                      '  ref_path as given: ' + str(path_as_inputted)]
             if relative_path != path_as_inputted:
                 lines.append('  resolved relative path: ' + str(relative_path))
             lines.append('  searched these roots in order (not found in any):')
             lines += ['    - ' + str(i) for i in searched]
+            # Mark each shared root available or not: without this, "the drive is not
+            # mounted" and "the file does not exist" produce an identical message.
+            for i in possible_dirs:
+                if isinstance(i, str) and i.startswith(SHARED_ROOT_SENTINEL_PREFIX):
+                    shared_root = i[len(SHARED_ROOT_SENTINEL_PREFIX):]
+                    state = 'available' if self.shared_root_is_available(shared_root) else 'NOT AVAILABLE on this machine'
+                    lines.append('    - shared data root (' + state + '): ' + str(shared_root))
             if 'input_bucket_name' in possible_dirs:
                 lines.append('    - cloud bucket: ' + str(self.input_bucket_name))
             lines.append('  If you expected this file to exist, check the ref_path spelling against base_data.')
@@ -903,7 +990,10 @@ class ProjectFlow(object):
         # current task is skipped and this call is only publishing a path. Return the
         # would-be path under the first root and log the assumption so a typo'd
         # ref_path leaves a diagnostic trail instead of silently producing a phantom path.
-        possible_dirs = [i for i in possible_dirs if i is not None and i != 'input_bucket_name']
+        # Drop the sentinels: what follows joins possible_dirs[0] as an actual directory,
+        # and neither the bucket nor a shared root is one.
+        possible_dirs = [i for i in possible_dirs if i is not None and i != 'input_bucket_name'
+                         and not (isinstance(i, str) and i.startswith(SHARED_ROOT_SENTINEL_PREFIX))]
         path = os.path.join(possible_dirs[0], relative_path)
         if in_skipped_task:
             hb.log('get_path (skipped task): ' + str(path_as_inputted) + ' was not found in any searched root; '

--- a/hazelbean/raster_vector_interface.py
+++ b/hazelbean/raster_vector_interface.py
@@ -1061,7 +1061,7 @@ def vector_super_simplify(input_vector_path, id_column_label, blur_size, output_
     
     base_data_dir = 'data'
     match_raster_path = os.path.join(base_data_dir, match_raster_refpath)
-    cloud_utils.download_gdrive_refpath(match_raster_path, base_data_dir)
+    cloud_utils.download_bucket_refpath(match_raster_path, base_data_dir)
     
     # Rasterize on id_column
     output_raster_path = os.path.splitext(output_path)[0] + '_raster_ids.tif'

--- a/hazelbean/setup_machine_env.py
+++ b/hazelbean/setup_machine_env.py
@@ -69,10 +69,7 @@ def _candidate_patterns():
         patterns += [
             drive + ':\\My Drive\\Files\\base_data' for drive in 'GHIJKLMNOPQRSTUVWXYZ'
         ]
-        patterns += [
-            os.path.join(home, 'Google Drive', 'Files', 'base_data'),
-            os.path.join(home, 'Dropbox', 'Files', 'base_data'),
-        ]
+        patterns.append(os.path.join(home, 'Google Drive', 'Files', 'base_data'))
     else:
         # No official Google Drive client exists for Linux and none is expected.
         # A shared root on Linux is a group scratch dir or network mount, which

--- a/hazelbean/setup_machine_env.py
+++ b/hazelbean/setup_machine_env.py
@@ -1,0 +1,234 @@
+"""Detect shared data roots on this machine and write them to machine.env.
+
+A shared data root is a read-only directory mirroring base_data's ref_path layout,
+usually a mounted lab drive. ProjectFlow.get_path searches configured roots after
+base_data_dir and before the cloud bucket, copying any hit into base_data_dir (see
+the get_path section of the EE conventions).
+
+Run once, deliberately:
+
+    hb-setup-machine-env            # scan, show findings, confirm, write
+    hb-setup-machine-env --print    # show what would be set, write nothing
+    hb-setup-machine-env --yes      # write without prompting (for scripted setup)
+
+Deliberately NOT done at install time or at import time:
+
+  - the conda-forge build of hazelbean never runs this repo's setup.py, so an
+    install-time hook would silently skip the most common onboarding path;
+  - detection at install time runs before the thing it is looking for exists --
+    people install the stack, then get added to the shared drive, then install
+    Drive for Desktop;
+  - a filesystem probe on every `import hazelbean` is pure waste on a cluster,
+    where the mount can never exist, and would make path resolution depend on
+    what happens to be mounted rather than on a config file someone can read.
+
+The result is a plain line in ~/.config/hazelbean/machine.env that can be read,
+edited, or deleted by hand. This script is a convenience, never a dependency.
+"""
+import argparse
+import glob
+import os
+import platform
+import sys
+
+from hazelbean.machine_env import USER_MACHINE_ENV_PATH
+
+SHARED_DATA_DIRS_KEY = 'HB_SHARED_DATA_DIRS'
+
+# A candidate is only accepted if it looks like base_data. Without this check the
+# globs below would happily match any directory that happened to be named right.
+BASE_DATA_MARKERS = ('cartographic', 'lulc', 'pyramids', 'crops', 'seals', 'luh2', 'global_invest')
+MINIMUM_MARKERS = 2
+
+# Bounded globs, never a walk: walking a cloud-sync tree wakes the sync client and
+# materializes placeholder files. Each pattern is anchored so it can only match a
+# base_data mirror a few levels inside a known mount point.
+def _candidate_patterns():
+    """Glob patterns for where a base_data mirror plausibly lives on this OS."""
+    home = os.path.expanduser('~')
+    system = platform.system()
+    patterns = []
+
+    if system == 'Darwin':
+        # Drive for Desktop (current) mounts per account under CloudStorage.
+        patterns += [
+            os.path.join(home, 'Library', 'CloudStorage', 'GoogleDrive-*', 'Shared drives', '*', 'Files', 'base_data'),
+            os.path.join(home, 'Library', 'CloudStorage', 'GoogleDrive-*', 'My Drive', 'Files', 'base_data'),
+            # Legacy mount point, still present on older installs.
+            os.path.join('/Volumes', 'GoogleDrive', 'Shared drives', '*', 'Files', 'base_data'),
+            # Other sync clients, same layout contract.
+            os.path.join(home, 'Library', 'CloudStorage', 'Dropbox*', 'Files', 'base_data'),
+            os.path.join(home, 'Library', 'CloudStorage', 'OneDrive-*', 'Files', 'base_data'),
+        ]
+    elif system == 'Windows':
+        # Drive for Desktop mounts as a drive letter (G: by default, configurable)
+        # or as a folder under the user profile.
+        patterns += [
+            drive + ':\\Shared drives\\*\\Files\\base_data' for drive in 'GHIJKLMNOPQRSTUVWXYZ'
+        ]
+        patterns += [
+            drive + ':\\My Drive\\Files\\base_data' for drive in 'GHIJKLMNOPQRSTUVWXYZ'
+        ]
+        patterns += [
+            os.path.join(home, 'Google Drive', 'Files', 'base_data'),
+            os.path.join(home, 'Dropbox', 'Files', 'base_data'),
+        ]
+    else:
+        # No official Google Drive client exists for Linux and none is expected.
+        # A shared root on Linux is a group scratch dir or network mount, which
+        # has no discoverable convention -- set HB_SHARED_DATA_DIRS by hand.
+        pass
+
+    # Any platform: a plain sync folder in the home dir.
+    patterns.append(os.path.join(home, 'Dropbox', 'Files', 'base_data'))
+    return patterns
+
+
+def score_candidate(candidate_dir):
+    """How many base_data marker directories a candidate contains (higher is better)."""
+    try:
+        children = set(os.listdir(candidate_dir))
+    except OSError:
+        # An unmounted or unauthenticated cloud dir can raise rather than be empty.
+        return 0
+    return len([i for i in BASE_DATA_MARKERS if i in children])
+
+
+def find_shared_data_root_candidates(verbose=False):
+    """Return [(path, marker_score), ...] for plausible base_data mirrors, best first.
+
+    Only directories that actually look like base_data are returned, so a stray
+    folder with the right name is never proposed.
+    """
+    found = {}
+    for pattern in _candidate_patterns():
+        try:
+            matches = glob.glob(pattern)
+        except OSError:
+            continue
+        for candidate_dir in matches:
+            if not os.path.isdir(candidate_dir) or candidate_dir in found:
+                continue
+            score = score_candidate(candidate_dir)
+            if verbose:
+                print('  checked (%d markers): %s' % (score, candidate_dir))
+            if score >= MINIMUM_MARKERS:
+                found[candidate_dir] = score
+    return sorted(found.items(), key=lambda i: (-i[1], i[0]))
+
+
+def read_existing_value(machine_env_path=None, key=SHARED_DATA_DIRS_KEY):
+    """The value already set for key in machine.env, or None. Never parses the wider env."""
+    if machine_env_path is None:
+        machine_env_path = USER_MACHINE_ENV_PATH
+    if not os.path.isfile(machine_env_path):
+        return None
+    with open(machine_env_path) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('export '):
+                line = line[len('export '):].strip()
+            if line.startswith(key + '='):
+                return line.split('=', 1)[1].strip()
+    return None
+
+
+def write_machine_env_value(value, machine_env_path=None, key=SHARED_DATA_DIRS_KEY):
+    """Append key=value to machine.env, creating the file and its directory if needed.
+
+    Never rewrites an existing key -- the caller checks read_existing_value first and
+    reports rather than clobbering, so a hand-edited config is always safe.
+    """
+    if machine_env_path is None:
+        machine_env_path = USER_MACHINE_ENV_PATH
+    config_dir = os.path.dirname(machine_env_path)
+    if config_dir and not os.path.isdir(config_dir):
+        os.makedirs(config_dir)
+
+    needs_newline = False
+    if os.path.isfile(machine_env_path) and os.path.getsize(machine_env_path) > 0:
+        with open(machine_env_path, 'rb') as f:
+            f.seek(-1, os.SEEK_END)
+            needs_newline = f.read(1) != b'\n'
+
+    with open(machine_env_path, 'a') as f:
+        if needs_newline:
+            f.write('\n')
+        f.write('\n# Shared data roots searched by ProjectFlow.get_path, after base_data_dir\n')
+        f.write('# and before the cloud bucket. Read-only; hits are cached into base_data.\n')
+        f.write('# Written by hb-setup-machine-env; edit or delete freely.\n')
+        f.write(key + '=' + value + '\n')
+    return machine_env_path
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog='hb-setup-machine-env',
+        description='Detect shared data roots (a mounted lab drive mirroring base_data) '
+                    'and record them in ~/.config/hazelbean/machine.env.')
+    parser.add_argument('--print', dest='print_only', action='store_true',
+                        help='show what would be set and exit without writing')
+    parser.add_argument('--yes', action='store_true',
+                        help='write the detected roots without prompting')
+    parser.add_argument('--verbose', action='store_true',
+                        help='show every candidate considered, including rejected ones')
+    args = parser.parse_args(argv)
+
+    machine_env_path = USER_MACHINE_ENV_PATH
+    print('Looking for shared data roots (a directory mirroring base_data)...')
+
+    existing = read_existing_value(machine_env_path)
+    candidates = find_shared_data_root_candidates(verbose=args.verbose)
+
+    if not candidates:
+        print('\nNo shared data root found on this machine.')
+        if platform.system() not in ('Darwin', 'Windows'):
+            print('Google Drive for Desktop has no Linux client, so nothing is detectable here.')
+            print('If a shared root exists (a group scratch dir, a network mount), set it by hand:')
+        else:
+            print('If your lab drive is mounted, it may not mirror base_data at')
+            print('<drive>/Files/base_data. Set it by hand:')
+        print('  %s=/path/to/base_data' % SHARED_DATA_DIRS_KEY)
+        print('  in %s' % machine_env_path)
+        print('\nThis is not a problem: with no shared root, get_path falls through to the')
+        print('cloud bucket, which works everywhere and needs no configuration.')
+        return 0
+
+    print('\nFound %d:' % len(candidates))
+    for candidate_dir, score in candidates:
+        print('  [%d/%d markers] %s' % (score, len(BASE_DATA_MARKERS), candidate_dir))
+
+    value = os.pathsep.join([i for i, _ in candidates])
+    line = SHARED_DATA_DIRS_KEY + '=' + value
+
+    if existing is not None:
+        print('\n%s is already set in %s:' % (SHARED_DATA_DIRS_KEY, machine_env_path))
+        print('  ' + existing)
+        print('\nLeaving it alone. To use what was detected instead, replace that line with:')
+        print('  ' + line)
+        return 0
+
+    if args.print_only:
+        print('\nWould add to %s:' % machine_env_path)
+        print('  ' + line)
+        return 0
+
+    if not args.yes:
+        print('\nAdd to %s:' % machine_env_path)
+        print('  ' + line)
+        try:
+            answer = input('\nWrite it? [y/N] ').strip().lower()
+        except EOFError:
+            answer = ''
+        if answer not in ('y', 'yes'):
+            print('Nothing written.')
+            return 1
+
+    write_machine_env_value(value, machine_env_path)
+    print('\nWrote %s' % machine_env_path)
+    print('New Python processes will pick it up; hazelbean loads machine.env on import.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/hazelbean_tests/unit/test_setup_machine_env.py
+++ b/hazelbean_tests/unit/test_setup_machine_env.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for hb-setup-machine-env, the one-shot shared-data-root detector.
+
+The script scans a few bounded, OS-specific locations for a directory that mirrors
+base_data, and records what it finds in ~/.config/hazelbean/machine.env so
+ProjectFlow.get_path can use it as a shared root.
+
+Covers:
+- a candidate is only accepted if it actually looks like base_data
+- writing creates the config dir, and appends safely to an existing file
+- an already-set key is reported, never clobbered
+- --print writes nothing
+- no candidates is a clean, informative exit rather than a failure
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+# NOTE: Awkward inclusion here so that I don't have to run the test via a setup config each time
+sys.path.extend(['../../..'])
+
+from hazelbean import setup_machine_env as sme
+
+
+class SetupMachineEnvTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.machine_env = os.path.join(self.tmp, 'config', 'machine.env')
+        # A directory that looks like base_data, and one that only shares its name.
+        self.real_mirror = os.path.join(self.tmp, 'drive', 'Files', 'base_data')
+        self.decoy = os.path.join(self.tmp, 'decoy', 'Files', 'base_data')
+        for marker in ('cartographic', 'lulc', 'pyramids'):
+            os.makedirs(os.path.join(self.real_mirror, marker))
+        os.makedirs(os.path.join(self.decoy, 'holiday_photos'))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TestCandidateScoring(SetupMachineEnvTest):
+
+    @pytest.mark.unit
+    def test_a_real_mirror_scores(self):
+        self.assertGreaterEqual(sme.score_candidate(self.real_mirror), sme.MINIMUM_MARKERS)
+
+    @pytest.mark.unit
+    def test_a_lookalike_does_not_score(self):
+        """Named base_data but holding none of its contents -- must not be proposed."""
+        self.assertLess(sme.score_candidate(self.decoy), sme.MINIMUM_MARKERS)
+
+    @pytest.mark.unit
+    def test_unreadable_dir_scores_zero_rather_than_raising(self):
+        """An unmounted or unauthenticated cloud dir can raise on listdir."""
+        with patch('os.listdir', side_effect=OSError('stale mount')):
+            self.assertEqual(sme.score_candidate(self.real_mirror), 0)
+
+    @pytest.mark.unit
+    def test_only_marker_bearing_candidates_are_returned(self):
+        with patch.object(sme, '_candidate_patterns',
+                          return_value=[os.path.join(self.tmp, '*', 'Files', 'base_data')]):
+            found = sme.find_shared_data_root_candidates()
+        paths = [i for i, _ in found]
+        self.assertIn(self.real_mirror, paths)
+        self.assertNotIn(self.decoy, paths)
+
+    @pytest.mark.unit
+    def test_linux_has_no_drive_patterns(self):
+        """Google Drive for Desktop has no Linux client, so nothing is detectable there."""
+        with patch('platform.system', return_value='Linux'):
+            patterns = sme._candidate_patterns()
+        self.assertFalse([i for i in patterns if 'CloudStorage' in i or 'Shared drives' in i])
+
+
+class TestWriting(SetupMachineEnvTest):
+
+    @pytest.mark.unit
+    def test_write_creates_config_dir(self):
+        sme.write_machine_env_value('/a/base_data', self.machine_env)
+        self.assertTrue(os.path.isfile(self.machine_env))
+        self.assertEqual(sme.read_existing_value(self.machine_env), '/a/base_data')
+
+    @pytest.mark.unit
+    def test_append_preserves_existing_keys(self):
+        os.makedirs(os.path.dirname(self.machine_env))
+        with open(self.machine_env, 'w') as f:
+            f.write('GTAP_SC_SLURM_ACCOUNT=abc')   # deliberately no trailing newline
+        sme.write_machine_env_value('/b/base_data', self.machine_env)
+        content = open(self.machine_env).read()
+        self.assertIn('GTAP_SC_SLURM_ACCOUNT=abc', content)
+        self.assertIn('HB_SHARED_DATA_DIRS=/b/base_data', content)
+        # The pre-existing key had no trailing newline; the new block must not be
+        # glued onto the end of it.
+        self.assertTrue(content.startswith('GTAP_SC_SLURM_ACCOUNT=abc\n'))
+        self.assertEqual(len(sme.read_existing_value(self.machine_env, 'GTAP_SC_SLURM_ACCOUNT') or ''), 3)
+
+    @pytest.mark.unit
+    def test_read_existing_handles_export_prefix(self):
+        os.makedirs(os.path.dirname(self.machine_env))
+        with open(self.machine_env, 'w') as f:
+            f.write('export HB_SHARED_DATA_DIRS=/c/base_data\n')
+        self.assertEqual(sme.read_existing_value(self.machine_env), '/c/base_data')
+
+    @pytest.mark.unit
+    def test_read_existing_returns_none_when_absent(self):
+        self.assertIsNone(sme.read_existing_value(self.machine_env))
+
+
+class TestMain(SetupMachineEnvTest):
+
+    def _run(self, argv, candidates=None):
+        candidates = self.real_mirror if candidates is None else candidates
+        found = [(candidates, 3)] if candidates else []
+        with patch.object(sme, 'USER_MACHINE_ENV_PATH', self.machine_env), \
+             patch.object(sme, 'find_shared_data_root_candidates', return_value=found):
+            return sme.main(argv)
+
+    @pytest.mark.unit
+    def test_print_only_writes_nothing(self):
+        self.assertEqual(self._run(['--print']), 0)
+        self.assertFalse(os.path.exists(self.machine_env))
+
+    @pytest.mark.unit
+    def test_yes_writes(self):
+        self.assertEqual(self._run(['--yes']), 0)
+        self.assertEqual(sme.read_existing_value(self.machine_env), self.real_mirror)
+
+    @pytest.mark.unit
+    def test_existing_value_is_never_clobbered(self):
+        os.makedirs(os.path.dirname(self.machine_env))
+        with open(self.machine_env, 'w') as f:
+            f.write('HB_SHARED_DATA_DIRS=/set/by/hand\n')
+        self.assertEqual(self._run(['--yes']), 0)
+        self.assertEqual(sme.read_existing_value(self.machine_env), '/set/by/hand')
+
+    @pytest.mark.unit
+    def test_no_candidates_exits_cleanly(self):
+        """Nothing found is a normal outcome, not a failure: the bucket still works."""
+        self.assertEqual(self._run(['--yes'], candidates=''), 0)
+        self.assertFalse(os.path.exists(self.machine_env))
+
+    @pytest.mark.unit
+    def test_declining_the_prompt_writes_nothing(self):
+        with patch('builtins.input', return_value='n'):
+            self.assertEqual(self._run([]), 1)
+        self.assertFalse(os.path.exists(self.machine_env))
+
+    @pytest.mark.unit
+    def test_accepting_the_prompt_writes(self):
+        with patch('builtins.input', return_value='y'):
+            self.assertEqual(self._run([]), 0)
+        self.assertEqual(sme.read_existing_value(self.machine_env), self.real_mirror)
+
+
+class TestGetPathHint(unittest.TestCase):
+
+    @pytest.mark.unit
+    def test_not_found_message_points_at_the_script(self):
+        """The hint must land where someone actually is: a failed resolution."""
+        import hazelbean as hb
+        tmp = tempfile.mkdtemp()
+        try:
+            p = hb.ProjectFlow(project_dir=os.path.join(tmp, 'proj'))
+            p.base_data_dir = os.path.join(tmp, 'base_data')
+            os.makedirs(p.base_data_dir)
+            p.shared_data_dirs = []
+            with self.assertRaises(NameError) as caught:
+                p.get_path(os.path.join('nowhere', 'absent.tif'))
+            message = str(caught.exception)
+            self.assertIn('No shared data roots are configured', message)
+            self.assertIn('hb-setup-machine-env', message)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    @pytest.mark.unit
+    def test_hint_is_absent_when_roots_are_configured(self):
+        import hazelbean as hb
+        tmp = tempfile.mkdtemp()
+        try:
+            p = hb.ProjectFlow(project_dir=os.path.join(tmp, 'proj'))
+            p.base_data_dir = os.path.join(tmp, 'base_data')
+            os.makedirs(p.base_data_dir)
+            p.shared_data_dirs = [os.path.join(tmp, 'some_root')]
+            with self.assertRaises(NameError) as caught:
+                p.get_path(os.path.join('nowhere', 'absent.tif'))
+            self.assertNotIn('hb-setup-machine-env', str(caught.exception))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hazelbean_tests/unit/test_shared_data_roots.py
+++ b/hazelbean_tests/unit/test_shared_data_roots.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for get_path's shared data root tier.
+
+A shared data root is a read-only directory that mirrors base_data's ref_path layout
+-- a mounted lab drive (Google Drive for Desktop, Dropbox), a group scratch dir, an
+external disk. get_path searches configured roots after base_data_dir and before the
+cloud bucket, and copies any hit into base_data_dir so later runs resolve locally.
+
+The tier is opportunistic by design: Google Drive for Desktop has no Linux client, so
+an absent root is the normal state on the cluster and must never be an error.
+
+Covers:
+- unset config is a strict no-op (the regression that matters most)
+- a configured-but-absent root falls through cleanly
+- a hit copies to base_data and returns the LOCAL path
+- the second call resolves locally without touching the root
+- sidecars come along; Google-native placeholders do not
+- an interrupted copy leaves no .partial behind for a later run to trust
+- the not-found message distinguishes "not mounted" from "not there"
+"""
+
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+# NOTE: Awkward inclusion here so that I don't have to run the test via a setup config each time
+sys.path.extend(['../../..'])
+
+import hazelbean as hb
+
+
+class SharedDataRootTest(unittest.TestCase):
+    """Base fixture: a project dir, a local base_data, and a fake shared root."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.project_dir = os.path.join(self.tmp, 'project')
+        self.base_data_dir = os.path.join(self.tmp, 'base_data')
+        self.shared_root = os.path.join(self.tmp, 'shared_drive', 'base_data')
+        os.makedirs(self.project_dir)
+        os.makedirs(self.base_data_dir)
+        os.makedirs(os.path.join(self.shared_root, 'global_invest', 'terrestrial_carbon'))
+
+        self.ref_path = os.path.join('global_invest', 'terrestrial_carbon', 'carbon_zones.tif')
+        self.shared_file = os.path.join(self.shared_root, self.ref_path)
+        with open(self.shared_file, 'wb') as f:
+            f.write(b'RASTERBYTES' * 100)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _project(self, shared_dirs=None):
+        p = hb.ProjectFlow(project_dir=self.project_dir)
+        p.base_data_dir = self.base_data_dir
+        p.shared_data_dirs = shared_dirs if shared_dirs is not None else []
+        return p
+
+    @property
+    def local_path(self):
+        return os.path.join(self.base_data_dir, self.ref_path)
+
+
+class TestNoOpWhenUnconfigured(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_unset_config_leaves_get_path_unchanged(self):
+        """No shared roots configured -> the file is simply not found, exactly as before.
+
+        This is the most important test in the file: the tier must be strictly additive.
+        """
+        p = self._project(shared_dirs=[])
+        with self.assertRaises(NameError):
+            p.get_path(self.ref_path)
+        self.assertFalse(os.path.exists(self.local_path),
+                         'nothing should have been cached when no root is configured')
+
+    @pytest.mark.unit
+    def test_env_var_absent_gives_empty_list(self):
+        """A ProjectFlow built with HB_SHARED_DATA_DIRS unset has no shared roots."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('HB_SHARED_DATA_DIRS', None)
+            p = hb.ProjectFlow(project_dir=self.project_dir)
+            self.assertEqual(p.shared_data_dirs, [])
+
+    @pytest.mark.unit
+    def test_env_var_is_pathsep_separated(self):
+        """Several roots can be configured at once, and blanks are dropped."""
+        value = os.pathsep.join([self.shared_root, '', '/nonexistent/second_root'])
+        with patch.dict(os.environ, {'HB_SHARED_DATA_DIRS': value}):
+            p = hb.ProjectFlow(project_dir=self.project_dir)
+            self.assertEqual(p.shared_data_dirs, [self.shared_root, '/nonexistent/second_root'])
+
+
+class TestAbsentRootFallsThrough(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_unmounted_root_is_skipped_not_raised(self):
+        """The normal state on Linux: configured, but no such directory. Must not blow up."""
+        p = self._project(shared_dirs=[os.path.join(self.tmp, 'not_mounted')])
+        self.assertFalse(p.shared_root_is_available(os.path.join(self.tmp, 'not_mounted')))
+        with self.assertRaises(NameError):
+            p.get_path(self.ref_path)   # falls through to not-found, not to a crash
+
+    @pytest.mark.unit
+    def test_availability_is_cached(self):
+        """get_path runs thousands of times per run; the root is stat-ed once per ProjectFlow."""
+        p = self._project(shared_dirs=[self.shared_root])
+        with patch('os.path.isdir', wraps=os.path.isdir) as spy:
+            p.shared_root_is_available(self.shared_root)
+            p.shared_root_is_available(self.shared_root)
+            p.shared_root_is_available(self.shared_root)
+            calls_on_root = [c for c in spy.call_args_list if c[0] and c[0][0] == self.shared_root]
+        self.assertEqual(len(calls_on_root), 1, 'availability should be cached after the first check')
+
+
+class TestHitCachesLocally(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_hit_returns_local_path_and_copies(self):
+        """A hit copies into base_data and returns the LOCAL path, not the shared one."""
+        p = self._project(shared_dirs=[self.shared_root])
+        got = p.get_path(self.ref_path)
+
+        self.assertEqual(got, self.local_path)
+        self.assertNotIn('shared_drive', got, 'must not hand back the shared-root path')
+        self.assertTrue(os.path.isfile(self.local_path))
+        with open(self.local_path, 'rb') as f:
+            self.assertEqual(f.read(), b'RASTERBYTES' * 100)
+
+    @pytest.mark.unit
+    def test_second_call_resolves_locally(self):
+        """Once cached, the shared root is not consulted again."""
+        p = self._project(shared_dirs=[self.shared_root])
+        p.get_path(self.ref_path)
+
+        # Make the shared root vanish; the ref_path must still resolve, from base_data.
+        shutil.rmtree(os.path.join(self.tmp, 'shared_drive'))
+        p2 = self._project(shared_dirs=[self.shared_root])
+        self.assertEqual(p2.get_path(self.ref_path), self.local_path)
+
+    @pytest.mark.unit
+    def test_local_base_data_wins_over_shared_root(self):
+        """base_data is searched first, so a local copy is never re-fetched."""
+        os.makedirs(os.path.dirname(self.local_path))
+        with open(self.local_path, 'wb') as f:
+            f.write(b'LOCAL')
+        p = self._project(shared_dirs=[self.shared_root])
+        got = p.get_path(self.ref_path)
+        with open(got, 'rb') as f:
+            self.assertEqual(f.read(), b'LOCAL', 'the local copy should not be overwritten')
+
+    @pytest.mark.unit
+    def test_shared_root_is_not_written_to(self):
+        """The contract is read-only: nothing new appears on the shared root."""
+        before = sorted(os.listdir(os.path.dirname(self.shared_file)))
+        p = self._project(shared_dirs=[self.shared_root])
+        p.get_path(self.ref_path)
+        after = sorted(os.listdir(os.path.dirname(self.shared_file)))
+        self.assertEqual(before, after)
+
+
+class TestSidecarsAndPlaceholders(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_gdal_sidecar_is_copied(self):
+        """Dropping .aux.xml is a silent stats/pyramid regression, not an error."""
+        with open(self.shared_file + '.aux.xml', 'w') as f:
+            f.write('<PAMDataset/>')
+        p = self._project(shared_dirs=[self.shared_root])
+        p.get_path(self.ref_path)
+        self.assertTrue(os.path.isfile(self.local_path + '.aux.xml'))
+
+    @pytest.mark.unit
+    def test_shapefile_siblings_are_copied(self):
+        """A .shp without its .dbf/.shx is unopenable, so the siblings must come along."""
+        vec_dir = os.path.join(self.shared_root, 'vec')
+        os.makedirs(vec_dir)
+        for extension in ('.shp', '.dbf', '.shx', '.prj'):
+            with open(os.path.join(vec_dir, 'countries' + extension), 'w') as f:
+                f.write(extension)
+
+        p = self._project(shared_dirs=[self.shared_root])
+        got = p.get_path(os.path.join('vec', 'countries.shp'))
+        copied = sorted(os.listdir(os.path.dirname(got)))
+        self.assertEqual(copied, ['countries.dbf', 'countries.prj', 'countries.shp', 'countries.shx'])
+
+    @pytest.mark.unit
+    def test_google_native_placeholder_is_not_a_match(self):
+        """A .gsheet on a mounted Drive is a ~100-byte JSON pointer, not data."""
+        ref = os.path.join('global_invest', 'terrestrial_carbon', 'notes.gsheet')
+        with open(os.path.join(self.shared_root, ref), 'w') as f:
+            f.write('{"doc_id": "abc123"}')
+        p = self._project(shared_dirs=[self.shared_root])
+        with self.assertRaises(NameError):
+            p.get_path(ref)
+        self.assertFalse(os.path.exists(os.path.join(self.base_data_dir, ref)))
+
+    @pytest.mark.unit
+    def test_is_google_native_file_helper(self):
+        self.assertTrue(hb.is_google_native_file('a/b/notes.gsheet'))
+        self.assertTrue(hb.is_google_native_file('a/b/NOTES.GDOC'))
+        self.assertFalse(hb.is_google_native_file('a/b/raster.tif'))
+
+
+class TestAtomicity(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_interrupted_copy_leaves_no_partial(self):
+        """A killed copy must not leave a truncated file that later passes path_exists."""
+        p = self._project(shared_dirs=[self.shared_root])
+        with patch('shutil.copyfile', side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                p.get_path(self.ref_path)
+
+        self.assertFalse(os.path.exists(self.local_path))
+        stray = []
+        for root, _dirs, files in os.walk(self.base_data_dir):
+            stray += [f for f in files if '.partial' in f]
+        self.assertEqual(stray, [], 'a .partial file must never survive a failed copy')
+
+    @pytest.mark.unit
+    def test_short_read_is_detected(self):
+        """A stalled mount that yields a truncated copy must raise, not cache."""
+        def _truncating_copy(src, dst):
+            with open(dst, 'wb') as f:
+                f.write(b'short')
+        p = self._project(shared_dirs=[self.shared_root])
+        with patch('shutil.copyfile', side_effect=_truncating_copy):
+            with self.assertRaises(IOError):
+                p.get_path(self.ref_path)
+        self.assertFalse(os.path.exists(self.local_path))
+
+
+class TestErrorMessage(SharedDataRootTest):
+
+    @pytest.mark.unit
+    def test_message_marks_root_unavailable(self):
+        """'Not mounted' and 'not there' must not produce identical messages."""
+        missing_root = os.path.join(self.tmp, 'not_mounted')
+        p = self._project(shared_dirs=[missing_root])
+        with self.assertRaises(NameError) as caught:
+            p.get_path(os.path.join('nowhere', 'absent.tif'))
+        message = str(caught.exception)
+        self.assertIn('shared data root', message)
+        self.assertIn('NOT AVAILABLE', message)
+        self.assertIn(missing_root, message)
+
+    @pytest.mark.unit
+    def test_message_marks_root_available(self):
+        p = self._project(shared_dirs=[self.shared_root])
+        with self.assertRaises(NameError) as caught:
+            p.get_path(os.path.join('nowhere', 'absent.tif'))
+        message = str(caught.exception)
+        self.assertIn('shared data root (available)', message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 [project.urls]
 homepage = "https://github.com/jandrewjohnson/hazelbean_dev"
 
+[project.scripts]
+# Run once, deliberately, to record a mounted lab drive in machine.env. Deliberately
+# not an install-time or import-time hook -- see hazelbean/setup_machine_env.py.
+hb-setup-machine-env = "hazelbean.setup_machine_env:main"
+
 [build-system]
 requires = [
         "setuptools>=61", "wheel", "cython>3",


### PR DESCRIPTION
Enhance the get_path function to resolve reference paths from read-only shared data roots, allowing for local caching of files. Introduce hb-setup-machine-env to assist users in configuring shared data directories. Update related functions and tests to ensure proper functionality and error handling.