### PR TITLE
ci: bump action-download-artifact past the artifact-poisoning advisory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,10 @@ jobs:
       # Download baseline from main branch
       - name: Download baseline from main branch
         id: download_baseline
-        uses: dawidd6/action-download-artifact@v3
+        # Pinned to a full commit SHA rather than a tag: a tag can be repointed,
+        # and this step consumes an artifact built by another workflow run, which
+        # is exactly the artifact-poisoning path GHSA flagged in v5 and earlier.
+        uses: dawidd6/action-download-artifact@57aa996fc1713cc1579039614f4645a7f4841fd4 # v23
         with:
           workflow: tests.yml
           branch: main


### PR DESCRIPTION
Dependabot flagged dawidd6/action-download-artifact@v3 as high severity: artifact poisoning in v5 and earlier, first patched in v6.

Moved to v23, the current release. All five inputs this step uses -- workflow, branch, name, path, if_no_artifact_found -- still exist in v23, so the jump needs no other changes.

Pinned to the full commit SHA rather than the tag. A tag is mutable and can be repointed at different code, and this step exists precisely to consume an artifact produced by a different workflow run, which is the trust boundary the advisory is about. Dependabot reads the trailing "# v23" comment and will still offer future bumps.